### PR TITLE
Improve Errors and Fix Documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ license = "MIT OR GPL-2.0"
 async-trait = "0.1.80"
 bytes = "1.6.0"
 clap = { version = "4.5.9", features = ["derive"] }
-die = "0.2.0"
 futures-core = "0.3.30"
 futures-util = "0.3.30"
 lazy_static = "1.4.0"

--- a/README.md
+++ b/README.md
@@ -164,7 +164,6 @@ Crosstalk currently uses Emacs-style keybindings for text manipulation. Although
 | End        | Move to the end of the line       |
 | C-l        | Clear the screen                  |
 | Tab        | Perform tab completion            |
-| C-i        | Insert a Tab                                         |
 | C-k        | Remove text from the cursor to the end of the line   |
 | C-u        | Remove text from the cursor to the start of the line |
 

--- a/src/cli/chat/repl.rs
+++ b/src/cli/chat/repl.rs
@@ -10,7 +10,7 @@ use reedline::{
 };
 use reedline::{DefaultPrompt, DefaultPromptSegment, EditCommand, MenuBuilder, Reedline, Signal};
 
-use die::die;
+use crate::die;
 use nu_ansi_term::{Color, Style};
 
 use super::tempfile::Tempfile;

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -1,17 +1,16 @@
 use nu_ansi_term::Color;
 use strum::IntoEnumIterator;
-use table::{IntoCell, IntoRow, IntoTable, Row, Table};
+use table::{IntoRow, IntoTable, Row, Table};
 mod table;
 
 use crate::{
-    providers::providers::ProviderIdentifier,
-    registry::{populate::populated_registry, registry::Registry},
-    ListArgs, ListObject, ListingFormat,
+    providers::providers::ProviderIdentifier, registry::registry::Registry, ListArgs, ListObject,
+    ListingFormat,
 };
 
 use crate::ColorMode;
 
-use die::die;
+use crate::die;
 
 #[derive(serde::Serialize)]
 struct Model {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,24 +1,22 @@
+use crate::die;
+use crate::warn;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use toml;
 
-// TODO: Rename "ActivationPolicy"
-// Auto
-// Disable
-// Enable
 #[derive(Deserialize, Serialize, Default, Clone, Copy, Debug)]
 #[serde(rename_all = "lowercase")]
-pub(crate) enum RequestedProviderActivation {
+pub(crate) enum ProviderActivationPolicy {
     #[default]
     Auto,
-    Yes,
-    No,
+    Enabled,
+    Disabled,
 }
 
 #[derive(Deserialize, Serialize, Default, Debug)]
 pub(crate) struct Ollama {
     #[serde(default)]
-    pub activate: RequestedProviderActivation,
+    pub activate: ProviderActivationPolicy,
     pub default_model: Option<String>,
     pub api_base: Option<String>,
     pub priority: Option<u8>,
@@ -27,7 +25,7 @@ pub(crate) struct Ollama {
 #[derive(Deserialize, Serialize, Default, Debug)]
 pub(crate) struct OpenAI {
     #[serde(default)]
-    pub activate: RequestedProviderActivation,
+    pub activate: ProviderActivationPolicy,
     pub default_model: Option<String>,
     pub api_key: Option<String>,
     pub priority: Option<u8>,
@@ -81,7 +79,7 @@ fn parse_config_or_die<'de, S: serde::de::DeserializeOwned>(config: &str) -> S {
 
     match r {
         Ok(s) => s,
-        Err(err) => die::die!("failed to parse config: {}", err),
+        Err(err) => die!("failed to parse config: {}", err),
     }
 }
 
@@ -108,8 +106,8 @@ fn warn_on_extra_fields_helper<'a>(
         } else {
             let path: Vec<&str> = path.iter().map(|&s| s.as_str()).collect();
 
-            eprintln!(
-                "warning: config contains extraneous key \"{}\", ignoring",
+            warn!(
+                "config contains extraneous key \"{}\", ignoring",
                 path.join(".")
             );
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod cli;
 mod config;
 mod providers;
 mod registry;
+mod utils;
 
 use std::path::PathBuf;
 
@@ -100,11 +101,29 @@ pub(crate) struct ListModelArgs {
     provider: Option<ProviderIdentifier>,
 }
 
+fn hook_panics_with_reporting() {
+    let default_hook = std::panic::take_hook();
+
+    std::panic::set_hook(Box::new(move |info| {
+        default_hook(info);
+
+        eprintln!("");
+        eprintln!("It seems you may have encountered a bug. If you believe something is not functioning correctly, we would greatly appreciate your help in reporting it. If you're using an older version, please consider updating to the latest release.");
+        eprintln!("");
+        eprintln!("As of this release, you can submit bug reports through the GitHub issue tracker, though this process may change in the future.");
+        eprintln!("See: https://github.com/flu0r1ne/crosstalk/issues/new?labels=bug&projects=&template=bug_report.md&title=Encountered%20a%20panic");
+    }));
+}
+
 #[tokio::main]
 async fn main() {
+    hook_panics_with_reporting();
+
     let cli = Cli::parse();
 
     let color = ColorMode::resolve_auto(cli.color);
+
+    utils::errors::configure_color(color);
 
     let config = read_config(cli.config);
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,1 @@
+pub(crate) mod errors;

--- a/src/utils/errors.rs
+++ b/src/utils/errors.rs
@@ -1,0 +1,78 @@
+use crate::cli::ColorMode;
+use nu_ansi_term::Color;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+pub const DEFAULT_EXIT_CODE: i32 = 1;
+
+static mut USE_COLOR: AtomicBool = AtomicBool::new(true);
+
+pub(crate) fn configure_color(cmode: ColorMode) {
+    match cmode {
+        ColorMode::On => unsafe {
+            USE_COLOR.store(true, Ordering::Relaxed);
+        },
+        ColorMode::Off => unsafe {
+            USE_COLOR.store(false, Ordering::Relaxed);
+        },
+    }
+}
+
+fn use_color() -> ColorMode {
+    match unsafe { USE_COLOR.load(Ordering::Relaxed) } {
+        true => ColorMode::On,
+        false => ColorMode::Off,
+    }
+}
+
+pub(crate) fn error_internal(text: &str) {
+    match use_color() {
+        ColorMode::On => {
+            let style = Color::Red.bold();
+            let text_style = Color::Default.bold();
+
+            eprintln!("{} {}", style.paint("error:"), text_style.paint(text));
+        }
+        ColorMode::Off => {
+            eprintln!("error: {}", text);
+        }
+    }
+}
+
+pub(crate) fn warn_internal(text: &str) {
+    match use_color() {
+        ColorMode::On => {
+            let style = Color::Yellow.bold();
+            let text_style = Color::Default.bold();
+
+            eprintln!("{} {}", style.paint("warning:"), text_style.paint(text));
+        }
+        ColorMode::Off => {
+            eprintln!("warning: {}", text);
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! warn {
+    ($($arg:tt)*) => ({
+        let formatted = format!($($arg)*);
+        $crate::utils::errors:: warn_internal(&formatted);
+    })
+}
+
+#[macro_export]
+macro_rules! error {
+    ($($arg:tt)*) => ({
+        let formatted = format!($($arg)*);
+        $crate::utils::errors:: error_internal(&formatted);
+    })
+}
+
+#[macro_export]
+macro_rules! die {
+    ($($arg:tt)*) => ({
+        let formatted = format!($($arg)*);
+        $crate::utils::errors::error_internal(&formatted);
+        ::std::process::exit($crate::utils::errors::DEFAULT_EXIT_CODE);
+    })
+}


### PR DESCRIPTION
This commit enhances user experience by improving error handling and refining documentation:

- Error and Warning Macros Added: Introduced new macros to provide color-coded error and warning messages. This update also eliminates the dependency on the external 'die' library by implementing an in-crate 'die' macro.
- Empty Registry Handling: Added checks to catch instances where the registry is empty, providing a more user-friendly message indicating that no providers are available. This is an improvement over the previous handling mechanism.
- Improved Registry Error Messages: Rewrote several error messages related to the registry.
- Documentation Update: Removed the documentation reference to the C-i tab keybinding, as it was both missing and difficult to implement.