### PR TITLE
Catch Control+C for Output Cancellation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xtalk"
 description = "A general-purpose CLI for chat models"
-version = "0.0.1-alpha.2"
+version = "0.0.1-alpha.3"
 edition = "2021"
 license = "MIT OR GPL-2.0"
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The `xtalk` alpha release only supports Linux.
 ## Installing with Cargo
 
 ```
-cargo install xtalk@0.0.1-alpha.2
+cargo install xtalk@0.0.1-alpha.3
 ```
 
 ### Building From Source

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod config;
 mod providers;
 mod registry;
 mod utils;
+mod version;
 
 use std::path::PathBuf;
 
@@ -26,11 +27,11 @@ pub(crate) enum RequestedColorMode {
 }
 
 #[derive(Parser)]
-#[command(name = "crosstalk")]
+#[command(name = version::NAME)]
 #[command(
     about = "A general-purpose CLI for chat models",
     author = "Alex <alex@al.exander.io>",
-    version = "0.0.1-alpha.2"
+    version = version::VERSION
 )]
 struct Cli {
     #[arg(long, default_value_t = RequestedColorMode::default())]

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,2 @@
+pub(crate) const VERSION: &'static str = "0.0.1-alpha.3"; 
+pub(crate) const NAME: &'static str = "xtalk";


### PR DESCRIPTION
This update allows the Control+C keyboard interrupt to be handled when output is produced. Users can now cancel the model's output if they determine it is incorrect. Please note that this content will not be added to the chat dialog.