### PR TITLE
Shell completion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT OR GPL-2.0"
 async-trait = "0.1.80"
 bytes = "1.6.0"
 clap = { version = "4.5.9", features = ["derive"] }
+clap_complete = "4.5.47"
 futures-core = "0.3.30"
 futures-util = "0.3.30"
 lazy_static = "1.4.0"

--- a/src/cli/chat.rs
+++ b/src/cli/chat.rs
@@ -282,7 +282,7 @@ async fn chat<'p>(
 
             msg_buf.add_message(Message::user(prompt));
         }
-       
+
         let completion = provider
             .stream_completion(&model_id, &msg_buf.chat_messages())
             .await;
@@ -330,7 +330,7 @@ async fn chat<'p>(
                                 print!("{}", delta.content);
                                 flush_or_die();
                             }
-        
+
                             msg_builder.add(&delta);
                         }
                         Err(err) => panic!("failed to decode streaming response: {}", err),
@@ -339,7 +339,7 @@ async fn chat<'p>(
                 _ = signal::ctrl_c() => {
                     skip_response = true;
                     break;
-                } 
+                }
             }
         }
 
@@ -361,7 +361,7 @@ async fn chat<'p>(
         if !interactive {
             break;
         }
- 
+
         pending_init_prompt = false;
     }
 }

--- a/src/cli/chat.rs
+++ b/src/cli/chat.rs
@@ -18,10 +18,9 @@ use crate::config;
 use crate::providers::{ChatProvider, ContextManagement, MessageDelta};
 use crate::registry::populate::resolve_once;
 use crate::registry::registry::{self, ModelSpec, Registry};
-use crate::ChatArgs;
+use crate::ChatOpts;
 use prompt::{model_prompt, user_prompt};
 use tokio::{select, signal};
-
 
 pub(crate) enum Severity {
     Error,
@@ -155,7 +154,7 @@ pub(crate) async fn chat_cmd(
     keybindings: config::Keybindings,
     default_model: Option<String>,
     registry: Registry,
-    args: &ChatArgs,
+    args: &ChatOpts,
 ) {
     let in_terminal = io::stdin().is_terminal();
     let out_terminal = io::stdout().is_terminal();

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,8 +33,8 @@ pub(crate) enum RequestedColorMode {
     author = "Alex <alex@al.exander.io>",
     version = version::VERSION
 )]
-struct Cli {
     #[arg(long, default_value_t = RequestedColorMode::default())]
+struct Opts {
     color: RequestedColorMode,
     #[arg(long)]
     config: Option<PathBuf>,
@@ -45,13 +45,13 @@ struct Cli {
 #[derive(Subcommand)]
 enum Commands {
     /// Start a chat
-    Chat(ChatArgs),
+    Chat(ChatOpts),
     /// List available models
     List(ListArgs),
 }
 
 #[derive(Parser, Default)]
-pub(crate) struct ChatArgs {
+pub(crate) struct ChatOpts {
     /// Specifies the model to be used during the chat
     #[arg(short, long)]
     model: Option<String>,
@@ -121,7 +121,7 @@ fn hook_panics_with_reporting() {
 async fn main() {
     hook_panics_with_reporting();
 
-    let cli = Cli::parse();
+    let cli = Opts::parse();
 
     let color = ColorMode::resolve_auto(cli.color);
 
@@ -151,7 +151,7 @@ async fn main() {
                 config.keybindings,
                 config.default_model,
                 registry,
-                &ChatArgs::default(),
+                &ChatOpts::default(),
             )
             .await
         }

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,2 +1,2 @@
-pub(crate) const VERSION: &'static str = "0.0.1-alpha.3"; 
+pub(crate) const VERSION: &'static str = "0.0.1-alpha.3";
 pub(crate) const NAME: &'static str = "xtalk";


### PR DESCRIPTION
Since this project already uses clap, it can leverage clap_complete to automatically generate completions for any shell. LMK if you'd be open to it.

I also added help text to opts `color` and `config`
![screenshot_2025-03-21_20-42-46_098262399](https://github.com/user-attachments/assets/aed4c54c-ceb7-4052-a5f7-23faa7347607)
![screenshot_2025-03-21_20-44-02_494942001](https://github.com/user-attachments/assets/570c912e-ca89-4488-b83e-f26383cd6a93)



The first commit can be culled but the names make more sense to me.